### PR TITLE
In mobile view the images are getting out of the screen #1

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ header{
 
 .gallery {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(350px, 100%), 1fr));
     padding: 2rem 0rem;
     width: 80%;
     margin: auto;


### PR DESCRIPTION
Hey there! Hope this commit helps with your project! I'm down to help continue contributing if you continue to grow in it!

I went ahead and updated your CSS on the grid-template-columns by still using your min of 350px but adding a little extra of 100% to ensure it'll take up 100% of the container’s width in case the container itself is less than 350px in width. Auto-fit would be ideal in this case so the content will stretch itself that it can fill the row entirely.