### PR TITLE
Search bar submits a query request with no search entry #5 fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,12 @@ function updateInput(e) {
 searchInput.addEventListener("input", updateInput);
 form.addEventListener("submit", (e) => {
   e.preventDefault();
-  currentSearch = searchValue;
-  searchPhotos(searchValue);
+  if (searchInput.value.trim() !== "") {
+    currentSearch = searchValue;
+    searchPhotos(searchValue);
+  } else {
+    alert('You must enter a valid entry to search.')
+  }
 });
 
 more.addEventListener("click", loadMore);


### PR DESCRIPTION
If condition was added to ensure that the searchInput value was not empty and also trimmed to ensure no trailing whitespace at beginning or end was causing error, this also helps prevent anyone searching empty spaces such as "   "

This should close out #5 